### PR TITLE
Spanish translation for email templates

### DIFF
--- a/com_zimbra_emailtemplates/com_zimbra_emailtemplates_es.properties
+++ b/com_zimbra_emailtemplates/com_zimbra_emailtemplates_es.properties
@@ -2,12 +2,12 @@
 # ***** BEGIN LICENSE BLOCK *****
 # Zimbra Collaboration Suite Web Client
 # Copyright (C) 2005, 2006, 2007, 2008, 2009, 2010 Zimbra, Inc.
-# 
+#
 # The contents of this file are subject to the Zimbra Public License
 # Version 1.3 ("License"); you may not use this file except in
 # compliance with the License.  You may obtain a copy of the License at
 # http://www.zimbra.com/license.
-# 
+#
 # Software distributed under the License is distributed on an "AS IS"
 # basis, WITHOUT WARRANTY OF ANY KIND, either express or implied.
 # ***** END LICENSE BLOCK *****
@@ -19,26 +19,26 @@ EmailTemplatesZimlet_bodyOnly=Insertar (solo el cuerpo)
 EmailTemplatesZimlet_bodyAndSubject=Insertar (cuerpo y asunto)
 EmailTemplatesZimlet_bodySubjectAndParticipants=Insertar (cuerpo, asunto y destinatarios)
 EmailTemplatesZimlet_reloadTemplates=Recargar plantillas
-EmailTemplatesZimlet_preferences=Configuracion
+EmailTemplatesZimlet_preferences=Configuraci&oacute;n
 EmailTemplatesZimlet_replaceTemplateData=Sustituir datos de plantillas
-EmailTemplatesZimlet_replaceGenericData=Por favor, sustituye los siguientes nombres genéricos por datos válidos
+EmailTemplatesZimlet_replaceGenericData=Por favor, sustituye los siguientes nombres genéricos por datos v&aacute;lidos
 EmailTemplatesZimlet_couldNotInsertApptAttendees=No se ha podido insertar los asistentes a la cita
-EmailTemplatesZimlet_templateFolderPath=Ruta de la carpeta de plantillas: 
+EmailTemplatesZimlet_templateFolderPath=Ruta de la carpeta de plantillas:
 EmailTemplatesZimlet_setTemplatesFolder=Fijar carpeta de plantillas
-EmailTemplatesZimlet_selectTemplatesFolder=Por favor indica dónde están guardadas las Plantillas
+EmailTemplatesZimlet_selectTemplatesFolder=Por favor indica donde estan guardadas las Plantillas
 EmailTemplatesZimlet_save=Guardar
-EmailTemplatesZimlet_saved=Plantilla guardada con éxito
+EmailTemplatesZimlet_saved=Plantilla guardada con &eacute;xito
 EmailTemplatesZimlet_saved_title=Plantilla guardada
-EmailTemplatesZimlet_restartBrowser=Se debe hacer un refresco completo la página para que los cambios sean efectivos. ¿Continuar?
+EmailTemplatesZimlet_restartBrowser=Se debe hacer un refresco completo la p&aacute;gina para que los cambios sean efectivos. ¿Continuar?
 EmailTemplatesZimlet_noSubject=No has indicado un asunto. Por favor, hazlo \
   antes de guardar la plantilla!
 EmailTemplatesZimlet_noSubject_title=No hay asunto
 
 #Help messages
-EmailTemplatesZimlet_genericNames=Nombres Genéricos
-EmailTemplatesZimlet_helpLine1=Puedes usar la técnica de los nombres genéricos para sustituir las partes comunes. Antes de insertar la plantilla <br/>el Zimlet te preguntará para reemplazarlas
+EmailTemplatesZimlet_genericNames=Nombres Gen&eacute;ricos
+EmailTemplatesZimlet_helpLine1=Puedes usar la t&eacute;cnica de los nombres gen&eacute;ricos para sustituir las partes comunes. Antes de insertar la plantilla <br/>el Zimlet te preguntar&aacute; para reemplazarlas
 EmailTemplatesZimlet_helpLine2=Por ejemplo: Puedes tener <strong>Hola ${firstName}</strong> en el cuerpo o el asunto
-EmailTemplatesZimlet_helpLine3=<strong>Reglas de Nombres Genéricos:</strong><br/>1. El nombre del genérico <strong>solo puede contener</strong> letras, números y el guion bajo 
+EmailTemplatesZimlet_helpLine3=<strong>Reglas de Nombres Gen&eacute;ricos:</strong><br/>1. El nombre del gen&eacute;rico <strong>solo puede contener</strong> letras, n&uacute;meros y el gui&oacute;n bajo
 EmailTemplatesZimlet_helpLine4=Por ejemplo: <strong>${firstName}</strong>, <strong>${first123}</strong> o  <strong>${First_Name}</strong>
-EmailTemplatesZimlet_helpLine5=2.Los Nombres Genéricos <strong>son senibles a las mayúsculas</strong>.
+EmailTemplatesZimlet_helpLine5=2.Los Nombres Gen&uacute;ricos <strong>son senibles a las may&uacute;sculas</strong>.
 EmailTemplatesZimlet_helpLine6=Por ejemplo:<strong>${firstName}</strong> y <strong>${FIRSTNAME}</strong> son considerados distintos


### PR DESCRIPTION
Spanish translation for com_zimbra_emailtemplates, used html entities because didn't seem to play well with UTF characters
